### PR TITLE
Search KList/TList by type eqv instead eq

### DIFF
--- a/modules/core/src/main/scala/iota/internal/CopKFunctionKMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/CopKFunctionKMacros.scala
@@ -24,7 +24,7 @@ import cats.instances.all._
 import scala.reflect.macros.whitebox.Context
 import scala.reflect.macros.TypecheckException
 
-final class CopKFunctionKMacros( val c: Context) {
+final class CopKFunctionKMacros(val c: Context) {
   import c.universe._
 
   private[this] lazy val klists = new SharedKListMacros[c.type](c)

--- a/modules/core/src/main/scala/iota/internal/KListMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/KListMacros.scala
@@ -42,7 +42,7 @@ class KListMacros(val c: Context) {
 
     result(for {
       algebras <- klists.klistTypesCached(L)
-      index    <- Right(algebras.indexWhere(_.dealias == F))
+      index    <- Right(algebras.indexWhere(_ =:= F))
                     .filterOrElse(_ >= 0, s"$F is not a member of $L")
     } yield
       q"new _root_.iota.KList.Pos[$L, $F]{ override val index: Int = $index }")

--- a/modules/core/src/main/scala/iota/internal/TListMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/TListMacros.scala
@@ -44,7 +44,7 @@ class TListMacros(val c: Context) {
 
     result(for {
       algebras <- tlistTypesCached(L)
-      index    <- Right(algebras.indexWhere(_.dealias == A))
+      index    <- Right(algebras.indexWhere(_ =:= A))
                     .filterOrElse(_ >= 0, s"$A is not a member of $L")
     } yield
       q"new _root_.iota.TList.Pos[$L, $A]{ override val index: Int = $index }")

--- a/modules/core/src/test/scala/iotatests/CopKTests.scala
+++ b/modules/core/src/test/scala/iotatests/CopKTests.scala
@@ -42,8 +42,13 @@ object CopKTests extends Properties("CopKTests") {
     case class Value(a: Int) extends Three[Int]
   }
 
-  type OneTwoThree = One :: Two :: Three :: KNil
-  type ThreeTwoOne = Three :: Two :: One :: KNil
+  type OneTwoThreeL = One :: Two :: Three :: KNil
+  type ThreeTwoOneL = Three :: Two :: One :: KNil
+
+  // these just need to compile
+  CopK.InjectL[One, OneTwoThreeL]
+  CopK.InjectL[CopKTests.One, OneTwoThreeL]
+  CopK.InjectL[_root_.iotatests.CopKTests.One, OneTwoThreeL]
 
   def checkInjectL[F[_], L <: KList, A](
     gen: Gen[F[A]],
@@ -53,43 +58,43 @@ object CopKTests extends Properties("CopKTests") {
     forAll(gen)(v =>
       inj.inj(v) ?= CopK(index, v))
 
-  property("inject One into OneTwoThree") =
+  property("inject One into OneTwoThreeL") =
     checkInjectL(
       arbitrary[One.Value],
-      CopK.InjectL[One, OneTwoThree],
+      CopK.InjectL[One, OneTwoThreeL],
       0)
 
-  property("inject Two into OneTwoThree") =
+  property("inject Two into OneTwoThreeL") =
     checkInjectL(
       arbitrary[Two.Value],
-      CopK.InjectL[Two, OneTwoThree],
+      CopK.InjectL[Two, OneTwoThreeL],
       1)
 
-  property("inject Three into OneTwoThree") =
+  property("inject Three into OneTwoThreeL") =
     checkInjectL(
       arbitrary[Three.Value],
-      CopK.InjectL[Three, OneTwoThree],
+      CopK.InjectL[Three, OneTwoThreeL],
       2)
 
-  property("inject One into ThreeTwoOne") =
+  property("inject One into ThreeTwoOneL") =
     checkInjectL(
       arbitrary[One.Value],
-      CopK.InjectL[One, ThreeTwoOne],
+      CopK.InjectL[One, ThreeTwoOneL],
       2)
 
-  property("inject Two into ThreeTwoOne") =
+  property("inject Two into ThreeTwoOneL") =
     checkInjectL(
       arbitrary[Two.Value],
-      CopK.InjectL[Two, ThreeTwoOne],
+      CopK.InjectL[Two, ThreeTwoOneL],
       1)
 
-  property("inject Three into ThreeTwoOne") =
+  property("inject Three into ThreeTwoOneL") =
     checkInjectL(
       arbitrary[Three.Value],
-      CopK.InjectL[Three, ThreeTwoOne],
+      CopK.InjectL[Three, ThreeTwoOneL],
       0)
 
-  type First[A] = A
+  type First[A] = String
   type Last[A] = A
   type Y[A]
 

--- a/modules/core/src/test/scala/iotatests/CopTests.scala
+++ b/modules/core/src/test/scala/iotatests/CopTests.scala
@@ -34,6 +34,11 @@ object CopTests extends Properties("CopTests") {
   type OneTwoThreeL = One :: Two :: Three :: TNil
   type ThreeTwoOneL = Three :: Two :: One :: TNil
 
+  // these just need to compile
+  Cop.InjectL[One, OneTwoThreeL]
+  Cop.InjectL[CopTests.One, OneTwoThreeL]
+  Cop.InjectL[_root_.iotatests.CopTests.One, OneTwoThreeL]
+
   def checkInjectL[A, L <: TList](
     gen: Gen[A],
     inj: Cop.InjectL[A, L],


### PR DESCRIPTION
This addresses a bug where some injection instances would fail to summon when types were equivalent but qualified differently.