### PR TITLE
Reorganize toolbelt code & other misc cleanup

### DIFF
--- a/modules/core/src/main/scala/iota/Cop.scala
+++ b/modules/core/src/main/scala/iota/Cop.scala
@@ -25,7 +25,7 @@ final class Cop[LL <: TList] private[iota](
 
   override def equals(anyOther: Any): Boolean = anyOther match {
     case other: Cop[LL] => (index == other.index) && (value == other.value)
-    case _             => false
+    case _              => false
   }
 
   override def toString: String =

--- a/modules/core/src/main/scala/iota/CopK.scala
+++ b/modules/core/src/main/scala/iota/CopK.scala
@@ -25,7 +25,7 @@ final class CopK[LL <: KList, A] private[iota](
 
   override def equals(anyOther: Any): Boolean = anyOther match {
     case other: CopK[LL, A] => (index == other.index) && (value == other.value)
-    case _                 => false
+    case _                => false
   }
 
   override def toString: String =

--- a/modules/core/src/main/scala/iota/internal/TypeListMacros.scala
+++ b/modules/core/src/main/scala/iota/internal/TypeListMacros.scala
@@ -19,10 +19,10 @@ package internal
 
 import scala.reflect.macros.blackbox.Context
 
-private[iota] final class TypeListMacros(
-  cc: Context
-) extends IotaMacroToolbelt(cc) {
+private[iota] final class TypeListMacros(val c: Context) {
   import c.universe._
+
+  private[this] val tb = IotaMacroToolbelt(c)
 
   def materializeTListPos[L <: TList, A](
     implicit
@@ -33,8 +33,8 @@ private[iota] final class TypeListMacros(
     val L = evL.tpe
     val A = evA.tpe
 
-    foldAbort(for {
-      algebras <- memoizedTListTypes(L)
+    tb.foldAbort(for {
+      algebras <- tb.memoizedTListTypes(L)
       index    <- Right(algebras.indexWhere(_ =:= A))
                     .filterOrElse(_ >= 0, s"$A is not a member of $L")
     } yield
@@ -50,8 +50,8 @@ private[iota] final class TypeListMacros(
     val L = evL.tpe
     val F = evF.tpe
 
-    foldAbort(for {
-      algebras <- memoizedKListTypes(L)
+    tb.foldAbort(for {
+      algebras <- tb.memoizedKListTypes(L)
       index    <- Right(algebras.indexWhere(_ =:= F))
                     .filterOrElse(_ >= 0, s"$F is not a member of $L")
     } yield
@@ -65,9 +65,9 @@ private[iota] final class TypeListMacros(
 
     val L = evL.tpe
 
-    foldAbort(for {
-      algebras <- memoizedTListTypes(L)
-      tpe       = buildTList(algebras)
+    tb.foldAbort(for {
+      algebras <- tb.memoizedTListTypes(L)
+      tpe       = tb.buildTList(algebras)
     } yield
       q"new _root_.iota.TList.Compute[$L]{ override type Out = $tpe }", true)
   }
@@ -79,9 +79,9 @@ private[iota] final class TypeListMacros(
 
     val L = evL.tpe
 
-    foldAbort(for {
-      algebras <- memoizedKListTypes(L)
-      tpe       = buildKList(algebras)
+    tb.foldAbort(for {
+      algebras <- tb.memoizedKListTypes(L)
+      tpe       = tb.buildKList(algebras)
     } yield
       q"new _root_.iota.KList.Compute[$L]{ override type Out = $tpe }", true)
   }

--- a/modules/core/src/test/scala/iota/internal/TestTreeHelper.scala
+++ b/modules/core/src/test/scala/iota/internal/TestTreeHelper.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//#+jvm
+
+package iota
+package internal
+
+import Recursion.Fix
+
+class TestTreeHelper(val tb: Toolbelt with TypeListTrees) {
+  import tb._
+  import tb.u.{ Type, WeakTypeTag }
+
+  def t[T](implicit evT: WeakTypeTag[T]): Type = evT.tpe
+
+  type Node = Fix[NodeF]
+
+  val nnil: Fix[NodeF] = Fix[NodeF](NNilF)
+  def cons[T](node: Fix[NodeF] = nnil)(implicit evT: WeakTypeTag[T]) = Fix[NodeF](ConsF(evT.tpe, node))
+  def consk[T[_]](node: Fix[NodeF] = nnil)(implicit evT: WeakTypeTag[T[_]]) = Fix[NodeF](ConsF(evT.tpe.typeConstructor, node))
+  def concat(nodes: Fix[NodeF]*)     = Fix[NodeF](ConcatF(nodes.toList))
+  def reverse(node: Fix[NodeF])      = Fix[NodeF](ReverseF(node))
+  def take(n: Int, node: Fix[NodeF]) = Fix[NodeF](TakeF(n, node))
+  def drop(n: Int, node: Fix[NodeF]) = Fix[NodeF](DropF(n, node))
+}
+
+//#-jvm

--- a/modules/core/src/test/scala/iota/internal/TypeListEvaluationChecks.scala
+++ b/modules/core/src/test/scala/iota/internal/TypeListEvaluationChecks.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//#+jvm
+
+package iota
+package internal
+
+import scala.Predef.ArrowAssoc
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+
+object TypeListEvaluationChecks extends Properties("TypeListEvaluators") {
+  import Recursion.cata
+
+  val checks = new TypeListEvaluationChecks(IotaReflectiveToolbelt())
+
+  checks.evalChecks.foreach { case (in, out) =>
+    property(s"eval $in") = cata(in)(checks.tb.evalTree) ?= out }
+}
+
+class TypeListEvaluationChecks(
+  override val tb: Toolbelt with TypeListEvaluators with TypeListTrees
+) extends TestTreeHelper(tb) {
+
+  import tb.u.Type
+
+  val evalChecks: List[(Node, List[Type])] = List(
+
+    nnil               -> (Nil),
+    reverse(nnil)      -> (Nil),
+    concat(nnil)       -> (Nil),
+    concat(nnil, nnil) -> (Nil),
+
+    cons[Int]()        -> (t[Int] :: Nil),
+    cons[String]()     -> (t[String] :: Nil),
+    cons[Double]()     -> (t[Double] :: Nil),
+
+    cons[Double](cons[String](cons[Int]()))
+      -> (t[Double] :: t[String] :: t[Int] :: Nil),
+
+    reverse(cons[Double](cons[String](cons[Int]())))
+      -> (t[Int] :: t[String] :: t[Double] :: Nil),
+
+    concat(
+      cons[Double](cons[String](cons[Int]())),
+      cons[Double](cons[String](cons[Int]()))
+    ) -> (t[Double] :: t[String] :: t[Int] :: t[Double] :: t[String] :: t[Int] :: Nil),
+
+    concat(
+      cons[Double](cons[String](cons[Int]())),
+      nnil,
+      cons[Double](cons[String](cons[Int]()))
+    ) -> (t[Double] :: t[String] :: t[Int] :: t[Double] :: t[String] :: t[Int] :: Nil),
+
+    concat(
+      cons[Double](cons[String](cons[Int]())),
+      reverse(cons[Double](cons[String](cons[Int]())))
+    ) -> (t[Double] :: t[String] :: t[Int] :: t[Int] :: t[String] :: t[Double] :: Nil),
+
+    take(0, cons[Double]())               -> (Nil),
+    take(1, cons[Double]())               -> (t[Double] :: Nil),
+    take(2, cons[Double]())               -> (t[Double] :: Nil),
+    take(0, cons[String](cons[Double]())) -> (Nil),
+    take(1, cons[String](cons[Double]())) -> (t[String] :: Nil),
+    take(2, cons[String](cons[Double]())) -> (t[String] :: t[Double] :: Nil),
+    take(3, cons[String](cons[Double]())) -> (t[String] :: t[Double] :: Nil),
+
+    drop(0, cons[Double]())               -> (t[Double] :: Nil),
+    drop(1, cons[Double]())               -> (Nil),
+    drop(2, cons[Double]())               -> (Nil),
+    drop(0, cons[String](cons[Double]())) -> (t[String] :: t[Double] :: Nil),
+    drop(1, cons[String](cons[Double]())) -> (t[Double] :: Nil),
+    drop(2, cons[String](cons[Double]())) -> (Nil),
+    drop(3, cons[String](cons[Double]())) -> (Nil)
+  )
+
+}
+
+//#-jvm

--- a/modules/core/src/test/scala/iota/internal/TypeListParserChecks.scala
+++ b/modules/core/src/test/scala/iota/internal/TypeListParserChecks.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//#+jvm
+
+package iota
+package internal
+
+import scala.Predef.ArrowAssoc
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+
+import cats.instances.either._
+
+import iotatests.FooAndFriends._
+
+object TypeListParserChecks extends Properties("TypeListParsers") {
+  import Recursion.anaM
+
+  val checks = new TypeListParserChecks(IotaReflectiveToolbelt())
+
+  checks.tlists.foreach { case (in, out) =>
+    property(s"parse TList $in") = anaM(in :: Nil)(checks.tb.parseTList.parse) ?= Right(out) }
+
+  checks.klists.foreach { case (in, out) =>
+    property(s"parse KList $in") = anaM(in :: Nil)(checks.tb.parseKList.parse) ?= Right(out) }
+
+}
+
+class TypeListParserChecks(
+  override val tb: Toolbelt with TypeListTrees with TypeListParsers
+) extends TestTreeHelper(tb) {
+
+  import tb.u.Type
+
+  import TList.::
+  import TList.Op.{
+    Concat  => TConcat,
+    Reverse => TReverse,
+    Take    => TTake,
+    Drop    => TDrop
+  }
+
+  val tlists: List[(Type, Node)] = List(
+    t[TNil] -> nnil,
+    t[Int :: TNil] -> cons[Int](),
+    t[String :: Int :: TNil] -> cons[String](cons[Int]()),
+
+    t[TReverse[TNil]] -> reverse(nnil),
+
+    t[Cop[BazBarFooL]#L] -> cons[Baz](cons[Bar](cons[Foo]())),
+
+    t[TConcat[BazBarFoo#L, FooBarBaz#L]] -> concat(
+      cons[Baz](cons[Bar](cons[Foo]())),
+      cons[Foo](cons[Bar](cons[Baz]()))
+    ),
+
+    t[TTake[0, BazBarFoo#L]] -> take(0, cons[Baz](cons[Bar](cons[Foo]()))),
+    t[TTake[1, BazBarFoo#L]] -> take(1, cons[Baz](cons[Bar](cons[Foo]()))),
+
+    t[TDrop[2, BazBarFoo#L]] -> drop(2, cons[Baz](cons[Bar](cons[Foo]()))),
+    t[TDrop[3, BazBarFoo#L]] -> drop(3, cons[Baz](cons[Bar](cons[Foo]())))
+  )
+
+  import KList.Op.{
+    Concat  => KConcat,
+    Reverse => KReverse,
+    Take    => KTake,
+    Drop    => KDrop
+  }
+
+  val klists: List[(Type, Node)] = List(
+
+    t[KReverse[KNil]] -> reverse(nnil),
+
+    t[CopK[BazBarFooKL, Nothing]#L] -> consk[BazK](consk[BarK](consk[FooK]())),
+
+    t[KConcat[BazBarFooK[_]#L, FooBarBazK[_]#L]] -> concat(
+      consk[BazK](consk[BarK](consk[FooK]())),
+      consk[FooK](consk[BarK](consk[BazK]()))
+    ),
+
+    t[KTake[0, BazBarFooK[_]#L]] -> take(0, consk[BazK](consk[BarK](consk[FooK]()))),
+    t[KTake[1, BazBarFooK[_]#L]] -> take(1, consk[BazK](consk[BarK](consk[FooK]()))),
+
+    t[KDrop[2, BazBarFooK[_]#L]] -> drop(2, consk[BazK](consk[BarK](consk[FooK]()))),
+    t[KDrop[3, BazBarFooK[_]#L]] -> drop(3, consk[BazK](consk[BarK](consk[FooK]())))
+  )
+
+}
+
+//#-jvm

--- a/modules/core/src/test/scala/iotatests/FooAndFriends.scala
+++ b/modules/core/src/test/scala/iotatests/FooAndFriends.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iotatests
+
+import iota._
+
+object FooAndFriends {
+
+  import TList.::
+
+  trait Foo
+  trait Bar
+  trait Baz
+
+  type FooBarBazL = Foo :: Bar :: Baz :: TNil
+  type BazBarFooL = Baz :: Bar :: Foo :: TNil
+
+  type FooBarBaz = Cop[FooBarBazL]
+  type BazBarFoo = Cop[BazBarFooL]
+
+
+  import KList.:::
+
+  trait FooK[A]
+  trait BarK[A]
+  trait BazK[A]
+
+  type FooBarBazKL = FooK ::: BarK ::: BazK ::: KNil
+  type BazBarFooKL = BazK ::: BarK ::: FooK ::: KNil
+
+  type FooBarBazK[A] = CopK[FooBarBazKL, A]
+  type BazBarFooK[A] = CopK[BazBarFooKL, A]
+
+}


### PR DESCRIPTION
Todo:

- [ ] organize tests for internal code such that `iota.internal.Recursion` can be marked package private